### PR TITLE
feat: add initial accscore package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # accs-core
-Core library for ACCS
+
+Core library for ACCS. Provides shared utilities for ACCS components.
+
+## Features
+
+- Environment settings loader with Pydantic.
+- SQLAlchemy database helpers.
+- MinIO storage helpers.
+- Pydantic schemas for job handling.
+
+## Installation
+
+```bash
+pip install accscore
+```
+
+## Development
+
+Install dependencies and run tests:
+
+```bash
+pip install -e .[test]
+pytest
+```

--- a/accscore/__init__.py
+++ b/accscore/__init__.py
@@ -1,0 +1,5 @@
+"""Core library for ACCS project."""
+
+from .version import __version__
+
+__all__ = ["__version__"]

--- a/accscore/db.py
+++ b/accscore/db.py
@@ -1,0 +1,39 @@
+"""Database utilities using SQLAlchemy."""
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from .settings import Settings
+
+
+settings = Settings()
+engine: Engine = create_engine(settings.postgres_dsn, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+    session: Session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def check_connection() -> bool:
+    """Check database connectivity."""
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False

--- a/accscore/schema/__init__.py
+++ b/accscore/schema/__init__.py
@@ -1,0 +1,19 @@
+"""Pydantic models used across ACCS components."""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class JobStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class Job(BaseModel):
+    id: str
+    status: JobStatus
+    result: Optional[str] = None

--- a/accscore/settings.py
+++ b/accscore/settings.py
@@ -1,0 +1,19 @@
+"""Environment configuration using Pydantic."""
+
+from pydantic import BaseSettings, Field
+from typing import Optional
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables or .env file."""
+
+    minio_endpoint: str = Field(..., env="MINIO_ENDPOINT")
+    minio_access_key: str = Field(..., env="MINIO_ACCESS_KEY")
+    minio_secret_key: str = Field(..., env="MINIO_SECRET_KEY")
+    postgres_dsn: str = Field(..., env="POSTGRES_DSN")
+    rabbitmq_url: Optional[str] = Field(None, env="RABBITMQ_URL")
+    service_url: Optional[str] = Field(None, env="SERVICE_URL")
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = False

--- a/accscore/storage.py
+++ b/accscore/storage.py
@@ -1,0 +1,44 @@
+"""MinIO storage helpers."""
+
+import io
+from datetime import timedelta
+from typing import Optional
+
+from minio import Minio
+
+from .settings import Settings
+
+
+settings = Settings()
+client = Minio(
+    settings.minio_endpoint,
+    access_key=settings.minio_access_key,
+    secret_key=settings.minio_secret_key,
+    secure=False,
+)
+
+
+def ensure_bucket(bucket: str) -> None:
+    """Create bucket if it does not exist."""
+    if not client.bucket_exists(bucket):
+        client.make_bucket(bucket)
+
+
+def put_object(bucket: str, name: str, data: bytes, content_type: Optional[str] = None) -> None:
+    """Upload bytes to object storage."""
+    client.put_object(bucket, name, io.BytesIO(data), len(data), content_type=content_type)
+
+
+def get_object(bucket: str, name: str) -> bytes:
+    """Download object as bytes."""
+    response = client.get_object(bucket, name)
+    try:
+        return response.read()
+    finally:
+        response.close()
+        response.release_conn()
+
+
+def presign(bucket: str, name: str, expires: timedelta = timedelta(hours=1)) -> str:
+    """Generate presigned download URL."""
+    return client.presigned_get_object(bucket, name, expires=expires)

--- a/accscore/version.py
+++ b/accscore/version.py
@@ -1,0 +1,3 @@
+"""Package version information."""
+
+__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "accscore"
+version = "0.1.0"
+description = "Core library for ACCS"
+authors = [{name = "ACCS"}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "pydantic>=1.10,<2",
+    "sqlalchemy>=1.4",
+    "minio>=7.1.0",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,12 @@
+from importlib import reload
+
+
+def test_check_connection(monkeypatch):
+    monkeypatch.setenv("MINIO_ENDPOINT", "localhost:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "key")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "secret")
+    monkeypatch.setenv("POSTGRES_DSN", "sqlite:///:memory:")
+    from accscore import db
+
+    reload(db)
+    assert db.check_connection() is True

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,7 @@
+from accscore.schema import Job, JobStatus
+
+
+def test_job_model():
+    job = Job(id="1", status=JobStatus.PENDING)
+    assert job.status == JobStatus.PENDING
+    assert job.result is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,15 @@
+import os
+from importlib import reload
+
+
+def test_settings_env(monkeypatch):
+    monkeypatch.setenv("MINIO_ENDPOINT", "localhost:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "key")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "secret")
+    monkeypatch.setenv("POSTGRES_DSN", "sqlite:///:memory:")
+    from accscore import settings as settings_module
+
+    reload(settings_module)
+    s = settings_module.Settings()
+    assert s.minio_endpoint == "localhost:9000"
+    assert s.postgres_dsn.startswith("sqlite")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,25 @@
+from importlib import reload
+
+
+def test_ensure_bucket(monkeypatch):
+    monkeypatch.setenv("MINIO_ENDPOINT", "localhost:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "key")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "secret")
+    monkeypatch.setenv("POSTGRES_DSN", "sqlite:///:memory:")
+    from accscore import storage
+
+    reload(storage)
+
+    class DummyClient:
+        def __init__(self):
+            self.created = []
+
+        def bucket_exists(self, name):
+            return False
+
+        def make_bucket(self, name):
+            self.created.append(name)
+
+    storage.client = DummyClient()
+    storage.ensure_bucket("test")
+    assert "test" in storage.client.created


### PR DESCRIPTION
## Summary
- bootstrap accscore package with settings, db and storage helpers
- add pydantic job schema and version module
- document and test initial release

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689491be4924832b81c55dc896d35620