### PR TITLE
Add workflow models and DB task claim helper

### DIFF
--- a/accscore/db.py
+++ b/accscore/db.py
@@ -1,7 +1,7 @@
 """Database utilities using SQLAlchemy."""
 
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Iterator, List, Dict, Any
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
@@ -37,3 +37,49 @@ def check_connection() -> bool:
         return True
     except Exception:
         return False
+
+
+def claim_tasks(session: Session, service: str, capacity: int, agent: str) -> List[Dict[str, Any]]:
+    """Claim queued tasks for a service respecting global job order.
+
+    Parameters
+    ----------
+    session:
+        Open SQLAlchemy session.
+    service:
+        Name of the service to claim tasks for.
+    capacity:
+        Maximum number of tasks to claim.
+    agent:
+        Identifier of the claiming agent.
+    """
+
+    sql = text(
+        """
+        WITH c AS (
+          SELECT jt.id
+          FROM job_tasks jt
+          JOIN jobs j ON j.id = jt.job_id
+          WHERE jt.service_name = :service
+            AND jt.status = 'queued'
+            AND (jt.next_attempt_at IS NULL OR jt.next_attempt_at <= now())
+            AND NOT EXISTS (
+              SELECT 1 FROM job_tasks dep
+              WHERE dep.job_id = jt.job_id
+                AND dep.task_key = ANY(jt.depends_on)
+                AND dep.status <> 'done'
+            )
+          ORDER BY j.order_seq ASC, jt.created_at ASC, jt.id ASC
+          FOR UPDATE SKIP LOCKED
+          LIMIT :capacity
+        )
+        UPDATE job_tasks t
+        SET status='starting', claimed_by=:agent, claimed_at=now()
+        FROM c
+        WHERE t.id = c.id
+        RETURNING t.*
+        """
+    )
+
+    result = session.execute(sql, {"service": service, "capacity": capacity, "agent": agent})
+    return [dict(row) for row in result.mappings()]

--- a/accscore/schema/__init__.py
+++ b/accscore/schema/__init__.py
@@ -1,19 +1,201 @@
-"""Pydantic models used across ACCS components."""
+"""Pydantic models and enums reflecting the ACCScore DB-driven workflow."""
 
+from __future__ import annotations
+
+from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Dict, List, Optional
+from uuid import UUID
 
 from pydantic import BaseModel
 
 
 class JobStatus(str, Enum):
-    PENDING = "pending"
+    """Possible states for a job."""
+
+    QUEUED = "queued"
     RUNNING = "running"
-    SUCCESS = "success"
-    FAILED = "failed"
+    DONE = "done"
+    ERROR = "error"
+
+
+class TaskStatus(str, Enum):
+    """States for individual job tasks."""
+
+    QUEUED = "queued"
+    STARTING = "starting"
+    RUNNING = "running"
+    DONE = "done"
+    ERROR = "error"
+    SKIPPED = "skipped"
+
+
+class EventLevel(str, Enum):
+    """Log levels for task events."""
+
+    DEBUG = "debug"
+    INFO = "info"
+    WARN = "warn"
+    ERROR = "error"
+
+
+class EventType(str, Enum):
+    """Types of task events."""
+
+    STATUS = "status"
+    PROGRESS = "progress"
+    LOG = "log"
+    ARTIFACT = "artifact"
+    HEARTBEAT = "heartbeat"
+    RETRY = "retry"
+
+
+class ArtifactKind(str, Enum):
+    """Kinds of artifacts a task can produce."""
+
+    INPUT = "input"
+    OUTPUT = "output"
+    LOG = "log"
+
+
+class AwakeState(str, Enum):
+    """Node awake state used by the node agent."""
+
+    UNKNOWN = "unknown"
+    AWAKE = "awake"
+    SLEEP = "sleep"
+
+
+class WakeMethod(str, Enum):
+    """How a node can be woken up."""
+
+    WOL = "wol"
+    PROVIDER = "provider"
+    SCRIPT = "script"
+
+
+class WorkflowStep(BaseModel):
+    """A single step definition inside a workflow."""
+
+    key: str
+    service: str
+    depends_on: List[str] = []
+    default_params: Dict[str, object] = {}
+
+
+class WorkflowDef(BaseModel):
+    """Workflow definition as stored in the database."""
+
+    id: Optional[UUID] = None
+    name: str
+    version: int
+    steps: List[WorkflowStep]
+    is_active: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 class Job(BaseModel):
-    id: str
+    """Job record representing a workflow execution."""
+
+    id: UUID
+    workflow_id: UUID
     status: JobStatus
-    result: Optional[str] = None
+    progress: Optional[float] = None
+    current_task_key: Optional[str] = None
+    priority: int = 0
+    order_seq: int
+    options: Dict[str, object] = {}
+    scheduled_at: Optional[datetime] = None
+    error_code: Optional[str] = None
+    error_message: Optional[str] = None
+    created_at: Optional[datetime] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class JobTask(BaseModel):
+    """Task belonging to a job."""
+
+    id: UUID
+    job_id: UUID
+    task_key: str
+    service_name: str
+    status: TaskStatus
+    depends_on: List[str] = []
+    attempt: int = 0
+    max_attempts: int = 3
+    next_attempt_at: Optional[datetime] = None
+    priority: int = 0
+    progress: Optional[float] = None
+    params: Dict[str, object] = {}
+    results: Dict[str, object] = {}
+    assigned_node: Optional[str] = None
+    claimed_by: Optional[str] = None
+    claimed_at: Optional[datetime] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class TaskEvent(BaseModel):
+    """Append-only event for jobs or tasks."""
+
+    id: Optional[int] = None
+    job_id: UUID
+    job_task_id: Optional[UUID] = None
+    ts: datetime
+    source: str
+    level: EventLevel
+    type: EventType
+    message: str
+    data: Dict[str, object] = {}
+
+
+class TaskArtifact(BaseModel):
+    """References to artifacts produced by tasks."""
+
+    id: Optional[int] = None
+    job_id: UUID
+    job_task_id: Optional[UUID] = None
+    kind: ArtifactKind
+    bucket: str
+    key: str
+    size_bytes: Optional[int] = None
+    content_type: Optional[str] = None
+    checksum: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+class Node(BaseModel):
+    """Service node participating in the workflow."""
+
+    name: str
+    labels: Dict[str, object] = {}
+    last_seen: Optional[datetime] = None
+    awake_state: AwakeState = AwakeState.UNKNOWN
+    wake_method: Optional[WakeMethod] = None
+    mac: Optional[str] = None
+    provider_ref: Optional[str] = None
+    script: Optional[str] = None
+    max_concurrency: Dict[str, int] = {}
+
+
+__all__ = [
+    "WorkflowStep",
+    "WorkflowDef",
+    "JobStatus",
+    "Job",
+    "TaskStatus",
+    "JobTask",
+    "EventLevel",
+    "EventType",
+    "TaskEvent",
+    "ArtifactKind",
+    "TaskArtifact",
+    "AwakeState",
+    "WakeMethod",
+    "Node",
+]
+

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,7 +1,39 @@
-from accscore.schema import Job, JobStatus
+from uuid import uuid4
+from uuid import uuid4
+
+from accscore.schema import (
+    Job,
+    JobStatus,
+    JobTask,
+    TaskStatus,
+    WorkflowDef,
+    WorkflowStep,
+)
+
+
+def test_workflow_model():
+    step = WorkflowStep(key="ingest", service="ingest")
+    wf = WorkflowDef(name="test", version=1, steps=[step])
+    assert wf.steps[0].key == "ingest"
 
 
 def test_job_model():
-    job = Job(id="1", status=JobStatus.PENDING)
-    assert job.status == JobStatus.PENDING
-    assert job.result is None
+    job = Job(
+        id=uuid4(),
+        workflow_id=uuid4(),
+        status=JobStatus.QUEUED,
+        order_seq=1,
+    )
+    assert job.status == JobStatus.QUEUED
+    assert job.progress is None
+
+
+def test_job_task_model():
+    jt = JobTask(
+        id=uuid4(),
+        job_id=uuid4(),
+        task_key="ingest",
+        service_name="ingest",
+        status=TaskStatus.QUEUED,
+    )
+    assert jt.status == TaskStatus.QUEUED


### PR DESCRIPTION
## Summary
- expand schema with enums and models for workflows, jobs, tasks, events, artifacts and nodes
- add `claim_tasks` helper implementing ordered task selection via SQL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f8577aa4832b842f6f7491dd4868