### PR TITLE
Harden models and settings, add DB helper scaffolding

### DIFF
--- a/accscore/db.py
+++ b/accscore/db.py
@@ -1,7 +1,7 @@
 """Database utilities using SQLAlchemy."""
 
 from contextlib import contextmanager
-from typing import Iterator, List, Dict, Any
+from typing import Iterator, List, Dict, Any, Optional
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
@@ -11,7 +11,7 @@ from .settings import Settings
 
 
 settings = Settings()
-engine: Engine = create_engine(settings.postgres_dsn, future=True)
+engine: Engine = create_engine(settings.postgres_dsn, future=True, pool_pre_ping=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
 
@@ -83,3 +83,138 @@ def claim_tasks(session: Session, service: str, capacity: int, agent: str) -> Li
 
     result = session.execute(sql, {"service": service, "capacity": capacity, "agent": agent})
     return [dict(row) for row in result.mappings()]
+
+
+def instantiate_tasks(session: Session, job_id: str) -> None:
+    """Instantiate job tasks for a job from its workflow definition."""
+    sql = text(
+        """
+        INSERT INTO job_tasks (job_id, task_key, service_name, status, depends_on, params)
+        SELECT :job_id, s.key, s.service, 'queued', COALESCE(s.depends_on, '{}'),
+               COALESCE(s.default_params, '{}')
+        FROM workflows w,
+             jsonb_to_recordset(w.steps) AS s(
+                 key TEXT,
+                 service TEXT,
+                 depends_on TEXT[],
+                 default_params JSONB
+             )
+        WHERE w.id = (SELECT workflow_id FROM jobs WHERE id = :job_id)
+        """
+    )
+    session.execute(sql, {"job_id": job_id})
+
+
+def mark_task_running(session: Session, task_id: str) -> None:
+    """Mark a task as running and set start timestamp."""
+    sql = text(
+        "UPDATE job_tasks SET status='running', started_at=COALESCE(started_at, now()) WHERE id=:task_id"
+    )
+    session.execute(sql, {"task_id": task_id})
+
+
+def update_task_progress(session: Session, task_id: str, percent: float) -> None:
+    """Update task progress percentage."""
+    sql = text("UPDATE job_tasks SET progress=:percent, updated_at=now() WHERE id=:task_id")
+    session.execute(sql, {"task_id": task_id, "percent": percent})
+
+
+def mark_task_done(session: Session, task_id: str, results: Optional[Dict[str, Any]] = None) -> None:
+    """Mark a task as done and optionally store results."""
+    sql = text(
+        "UPDATE job_tasks SET status='done', results=COALESCE(:results, results), finished_at=now() WHERE id=:task_id"
+    )
+    session.execute(sql, {"task_id": task_id, "results": results})
+
+
+def mark_task_error(
+    session: Session, task_id: str, error_code: str, message: str
+) -> None:
+    """Mark a task as errored and store error info."""
+    sql = text(
+        """
+        UPDATE job_tasks
+        SET status='error', finished_at=now(),
+            results=jsonb_set(COALESCE(results, '{}'::jsonb), '{error}', to_jsonb(:error_info))
+        WHERE id=:task_id
+        """
+    )
+    session.execute(sql, {"task_id": task_id, "error_info": {"code": error_code, "message": message}})
+
+
+def append_event(
+    session: Session,
+    *,
+    job_id: str,
+    job_task_id: Optional[str] = None,
+    level: str = "info",
+    type: str = "log",
+    message: str = "",
+    data: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Insert a new event row."""
+    sql = text(
+        "INSERT INTO task_events (job_id, job_task_id, ts, source, level, type, message, data)"
+        " VALUES (:job_id, :job_task_id, now(), :source, :level, :type, :message, :data)"
+    )
+    session.execute(
+        sql,
+        {
+            "job_id": job_id,
+            "job_task_id": job_task_id,
+            "source": "builder",
+            "level": level,
+            "type": type,
+            "message": message,
+            "data": data or {},
+        },
+    )
+
+
+def record_artifact(
+    session: Session,
+    *,
+    job_id: str,
+    job_task_id: Optional[str] = None,
+    kind: str,
+    bucket: str,
+    key: str,
+    size: Optional[int] = None,
+    content_type: Optional[str] = None,
+    checksum: Optional[str] = None,
+) -> None:
+    """Insert artifact metadata."""
+    sql = text(
+        """
+        INSERT INTO task_artifacts (job_id, job_task_id, kind, bucket, key, size_bytes, content_type, checksum, created_at)
+        VALUES (:job_id, :job_task_id, :kind, :bucket, :key, :size, :content_type, :checksum, now())
+        """
+    )
+    session.execute(
+        sql,
+        {
+            "job_id": job_id,
+            "job_task_id": job_task_id,
+            "kind": kind,
+            "bucket": bucket,
+            "key": key,
+            "size": size,
+            "content_type": content_type,
+            "checksum": checksum,
+        },
+    )
+
+
+def maybe_finish_job(session: Session, job_id: str) -> None:
+    """If all tasks are done or skipped, mark the job as finished."""
+    sql = text(
+        """
+        UPDATE jobs
+        SET status='done', finished_at=now()
+        WHERE id=:job_id
+          AND NOT EXISTS (
+            SELECT 1 FROM job_tasks WHERE job_id=:job_id AND status NOT IN ('done','skipped')
+          )
+        """
+    )
+    session.execute(sql, {"job_id": job_id})

--- a/accscore/schema/__init__.py
+++ b/accscore/schema/__init__.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Dict, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class JobStatus(str, Enum):
@@ -79,8 +79,8 @@ class WorkflowStep(BaseModel):
 
     key: str
     service: str
-    depends_on: List[str] = []
-    default_params: Dict[str, object] = {}
+    depends_on: List[str] = Field(default_factory=list)
+    default_params: Dict[str, object] = Field(default_factory=dict)
 
 
 class WorkflowDef(BaseModel):
@@ -105,7 +105,7 @@ class Job(BaseModel):
     current_task_key: Optional[str] = None
     priority: int = 0
     order_seq: int
-    options: Dict[str, object] = {}
+    options: Dict[str, object] = Field(default_factory=dict)
     scheduled_at: Optional[datetime] = None
     error_code: Optional[str] = None
     error_message: Optional[str] = None
@@ -123,19 +123,20 @@ class JobTask(BaseModel):
     task_key: str
     service_name: str
     status: TaskStatus
-    depends_on: List[str] = []
+    depends_on: List[str] = Field(default_factory=list)
     attempt: int = 0
     max_attempts: int = 3
     next_attempt_at: Optional[datetime] = None
     priority: int = 0
     progress: Optional[float] = None
-    params: Dict[str, object] = {}
-    results: Dict[str, object] = {}
+    params: Dict[str, object] = Field(default_factory=dict)
+    results: Dict[str, object] = Field(default_factory=dict)
     assigned_node: Optional[str] = None
     claimed_by: Optional[str] = None
     claimed_at: Optional[datetime] = None
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
 
@@ -150,7 +151,7 @@ class TaskEvent(BaseModel):
     level: EventLevel
     type: EventType
     message: str
-    data: Dict[str, object] = {}
+    data: Dict[str, object] = Field(default_factory=dict)
 
 
 class TaskArtifact(BaseModel):
@@ -172,14 +173,14 @@ class Node(BaseModel):
     """Service node participating in the workflow."""
 
     name: str
-    labels: Dict[str, object] = {}
+    labels: Dict[str, object] = Field(default_factory=dict)
     last_seen: Optional[datetime] = None
     awake_state: AwakeState = AwakeState.UNKNOWN
     wake_method: Optional[WakeMethod] = None
     mac: Optional[str] = None
     provider_ref: Optional[str] = None
     script: Optional[str] = None
-    max_concurrency: Dict[str, int] = {}
+    max_concurrency: Dict[str, int] = Field(default_factory=dict)
 
 
 __all__ = [

--- a/accscore/settings.py
+++ b/accscore/settings.py
@@ -7,10 +7,11 @@ from typing import Optional
 class Settings(BaseSettings):
     """Application settings loaded from environment variables or .env file."""
 
-    minio_endpoint: str = Field(..., env="MINIO_ENDPOINT")
-    minio_access_key: str = Field(..., env="MINIO_ACCESS_KEY")
-    minio_secret_key: str = Field(..., env="MINIO_SECRET_KEY")
-    postgres_dsn: str = Field(..., env="POSTGRES_DSN")
+    minio_endpoint: str = Field(..., env=["ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT"])
+    minio_access_key: str = Field(..., env=["ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY"])
+    minio_secret_key: str = Field(..., env=["ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY"])
+    minio_secure: bool = Field(False, env=["ACC_MINIO_SECURE", "MINIO_SECURE"])
+    postgres_dsn: str = Field(..., env=["ACC_DB_URL", "POSTGRES_DSN"])
     rabbitmq_url: Optional[str] = Field(None, env="RABBITMQ_URL")
     service_url: Optional[str] = Field(None, env="SERVICE_URL")
 

--- a/accscore/storage.py
+++ b/accscore/storage.py
@@ -14,7 +14,7 @@ client = Minio(
     settings.minio_endpoint,
     access_key=settings.minio_access_key,
     secret_key=settings.minio_secret_key,
-    secure=False,
+    secure=settings.minio_secure,
 )
 
 
@@ -42,3 +42,19 @@ def get_object(bucket: str, name: str) -> bytes:
 def presign(bucket: str, name: str, expires: timedelta = timedelta(hours=1)) -> str:
     """Generate presigned download URL."""
     return client.presigned_get_object(bucket, name, expires=expires)
+
+
+def build_key(
+    job_id: str,
+    task_key: str,
+    kind: str,
+    filename: Optional[str] = None,
+    ext: Optional[str] = None,
+) -> str:
+    """Construct object storage key according to repository conventions."""
+    base = f"{kind}/{job_id}/{task_key}"
+    if filename:
+        return f"{base}/{filename}"
+    if ext:
+        return f"{base}/{task_key}{ext}"
+    return base + "/"

--- a/docs/accscore_fejlesztoi_specifikacio_db_vezerelt_workflow.md
+++ b/docs/accscore_fejlesztoi_specifikacio_db_vezerelt_workflow.md
@@ -91,6 +91,7 @@ claimed_by TEXT NULL
 claimed_at timestamptz
 started_at timestamptz
 finished_at timestamptz
+created_at timestamptz NOT NULL DEFAULT now()
 updated_at timestamptz
 INDEX(service_name, status)
 INDEX(job_id, status)
@@ -292,6 +293,7 @@ ACC_DB_URL=postgresql+psycopg://user:pass@host:5432/accs
 ACC_MINIO_ENDPOINT=http://minio:9000
 ACC_MINIO_ACCESS_KEY=...
 ACC_MINIO_SECRET_KEY=...
+ACC_MINIO_SECURE=false
 ACC_NODE_NAME=gpu-node-1
 ACC_NODE_LABELS=gpu=true,zone=eu
 ACC_MAX_CONCURRENCY_RENDER=2

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,4 @@
 from uuid import uuid4
-from uuid import uuid4
 
 from accscore.schema import (
     Job,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,13 +3,15 @@ from importlib import reload
 
 
 def test_settings_env(monkeypatch):
-    monkeypatch.setenv("MINIO_ENDPOINT", "localhost:9000")
-    monkeypatch.setenv("MINIO_ACCESS_KEY", "key")
-    monkeypatch.setenv("MINIO_SECRET_KEY", "secret")
-    monkeypatch.setenv("POSTGRES_DSN", "sqlite:///:memory:")
+    monkeypatch.setenv("ACC_MINIO_ENDPOINT", "localhost:9000")
+    monkeypatch.setenv("ACC_MINIO_ACCESS_KEY", "key")
+    monkeypatch.setenv("ACC_MINIO_SECRET_KEY", "secret")
+    monkeypatch.setenv("ACC_MINIO_SECURE", "true")
+    monkeypatch.setenv("ACC_DB_URL", "sqlite:///:memory:")
     from accscore import settings as settings_module
 
     reload(settings_module)
     s = settings_module.Settings()
     assert s.minio_endpoint == "localhost:9000"
     assert s.postgres_dsn.startswith("sqlite")
+    assert s.minio_secure is True

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -23,3 +23,15 @@ def test_ensure_bucket(monkeypatch):
     storage.client = DummyClient()
     storage.ensure_bucket("test")
     assert "test" in storage.client.created
+
+
+def test_build_key(monkeypatch):
+    monkeypatch.setenv("MINIO_ENDPOINT", "localhost:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "key")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "secret")
+    monkeypatch.setenv("POSTGRES_DSN", "sqlite:///:memory:")
+    from accscore import storage
+
+    reload(storage)
+    key = storage.build_key("job1", "taskA", "inputs", filename="file.txt")
+    assert key == "inputs/job1/taskA/file.txt"


### PR DESCRIPTION
## Summary
- avoid mutable defaults in schema models and add `created_at` field for job tasks
- support ACC_* env vars, secure MinIO connections, and object key helper
- extend database helpers with task lifecycle operations and use a pre-ping engine

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895fd223408832b85559cbba77a41c0