### PR TITLE
Add storage key builder helper

### DIFF
--- a/accscore/storage.py
+++ b/accscore/storage.py
@@ -2,7 +2,8 @@
 
 import io
 from datetime import timedelta
-from typing import Optional
+from typing import Literal, Optional
+from uuid import UUID
 
 from minio import Minio
 
@@ -45,16 +46,10 @@ def presign(bucket: str, name: str, expires: timedelta = timedelta(hours=1)) -> 
 
 
 def build_key(
-    job_id: str,
+    kind: Literal["input", "output", "log"],
+    job_id: UUID,
     task_key: str,
-    kind: str,
-    filename: Optional[str] = None,
-    ext: Optional[str] = None,
+    filename: str,
 ) -> str:
     """Construct object storage key according to repository conventions."""
-    base = f"{kind}/{job_id}/{task_key}"
-    if filename:
-        return f"{base}/{filename}"
-    if ext:
-        return f"{base}/{task_key}{ext}"
-    return base + "/"
+    return f"{kind}/{job_id}/{task_key}/{filename}"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,5 @@
 from importlib import reload
+from uuid import uuid4
 
 
 def test_ensure_bucket(monkeypatch):
@@ -33,5 +34,6 @@ def test_build_key(monkeypatch):
     from accscore import storage
 
     reload(storage)
-    key = storage.build_key("job1", "taskA", "inputs", filename="file.txt")
-    assert key == "inputs/job1/taskA/file.txt"
+    job_id = uuid4()
+    key = storage.build_key("input", job_id, "taskA", "file.txt")
+    assert key == f"input/{job_id}/taskA/file.txt"


### PR DESCRIPTION
## Summary
- simplify building MinIO object keys via new `build_key` helper
- cover storage key generation with a unit test

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962217aa94832b989f5346a97f5cf6