### PR TITLE
Add event logging helper and tests

### DIFF
--- a/accscore/db/__init__.py
+++ b/accscore/db/__init__.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker, Session
 
-from .settings import Settings
+from ..settings import Settings
 
 
 settings = Settings()

--- a/accscore/db/events.py
+++ b/accscore/db/events.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from datetime import datetime
+import json
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+
+_ALLOWED_LEVELS = {"debug", "info", "warn", "error"}
+_ALLOWED_TYPES = {"status", "progress", "log", "artifact", "heartbeat", "retry"}
+
+
+def log_event(
+    level: str,
+    type: str,
+    message: str,
+    *,
+    data: Optional[Dict[str, Any]] = None,
+    job_id: Optional[str] = None,
+    job_task_id: Optional[str] = None,
+    source: str = "service:unknown",
+    conn: Connection,
+    ts: Optional[datetime] = None,
+) -> int:
+    """Insert a row into ``task_events`` and return the new id.
+
+    Parameters
+    ----------
+    level:
+        Log level, must be one of ``debug``, ``info``, ``warn``, ``error``.
+    type:
+        Event type according to specification.
+    message:
+        Event message text.
+    data:
+        Optional JSON serialisable payload.
+    job_id:
+        Related job identifier. Required unless ``job_task_id`` is provided
+        and resolves to a job.
+    job_task_id:
+        Optional task identifier. When provided the function validates that
+        the supplied ``job_id`` matches the task's job.
+    source:
+        Source string, defaults to ``service:unknown``.
+    conn:
+        Open SQLAlchemy connection.
+    ts:
+        Optional timestamp. If omitted the database current timestamp is used.
+    """
+
+    if level not in _ALLOWED_LEVELS:
+        raise ValueError(f"invalid level: {level!r}")
+    if type not in _ALLOWED_TYPES:
+        raise ValueError(f"invalid type: {type!r}")
+
+    # sanity check for job/task relation
+    if job_task_id is not None:
+        row = conn.execute(
+            text("SELECT job_id FROM job_tasks WHERE id = :tid"), {"tid": job_task_id}
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"job_task_id {job_task_id!r} not found")
+        task_job_id = row[0]
+        if job_id is None:
+            job_id = task_job_id
+        elif job_id != task_job_id:
+            raise ValueError("job_id does not match job_task_id")
+
+    if job_id is None:
+        raise ValueError("job_id is required")
+
+    payload = data or {}
+    if conn.dialect.name == "sqlite":
+        payload = json.dumps(payload)
+
+    sql = text(
+        """
+        INSERT INTO task_events (job_id, job_task_id, ts, source, level, type, message, data)
+        VALUES (:job_id, :job_task_id, COALESCE(:ts, CURRENT_TIMESTAMP), :source, :level, :type, :message, :data)
+        RETURNING id
+        """
+    )
+
+    result = conn.execute(
+        sql,
+        {
+            "job_id": job_id,
+            "job_task_id": job_task_id,
+            "ts": ts,
+            "source": source,
+            "level": level,
+            "type": type,
+            "message": message,
+            "data": payload,
+        },
+    )
+    return result.scalar_one()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,103 @@
+import pytest
+from sqlalchemy import create_engine, text
+
+
+def setup_env(monkeypatch):
+    monkeypatch.setenv("MINIO_ENDPOINT", "localhost:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "key")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "secret")
+    monkeypatch.setenv("POSTGRES_DSN", "sqlite:///:memory:")
+
+
+# Smoke tests for log_event
+
+def test_log_event_basic(monkeypatch):
+    setup_env(monkeypatch)
+    from accscore.db.events import log_event
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE job_tasks (id TEXT PRIMARY KEY, job_id TEXT NOT NULL)"))
+        conn.execute(
+            text(
+                """
+                CREATE TABLE task_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    job_id TEXT NOT NULL,
+                    job_task_id TEXT,
+                    ts TEXT NOT NULL,
+                    source TEXT,
+                    level TEXT,
+                    type TEXT,
+                    message TEXT,
+                    data TEXT
+                )
+                """
+            )
+        )
+
+        event_id = log_event("info", "log", "hello", job_id="job1", conn=conn)
+        row = conn.execute(text("SELECT message FROM task_events WHERE id=:id"), {"id": event_id}).one()
+        assert row[0] == "hello"
+
+
+def test_log_event_with_task(monkeypatch):
+    setup_env(monkeypatch)
+    from accscore.db.events import log_event
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE job_tasks (id TEXT PRIMARY KEY, job_id TEXT NOT NULL)"))
+        conn.execute(
+            text(
+                """
+                CREATE TABLE task_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    job_id TEXT NOT NULL,
+                    job_task_id TEXT,
+                    ts TEXT NOT NULL,
+                    source TEXT,
+                    level TEXT,
+                    type TEXT,
+                    message TEXT,
+                    data TEXT
+                )
+                """
+            )
+        )
+        conn.execute(text("INSERT INTO job_tasks (id, job_id) VALUES ('t1','j1')"))
+
+        event_id = log_event("info", "log", "hi", job_task_id="t1", conn=conn)
+        row = conn.execute(text("SELECT job_id, job_task_id FROM task_events WHERE id=:id"), {"id": event_id}).one()
+        assert row[0] == "j1"
+        assert row[1] == "t1"
+
+
+def test_log_event_mismatched_job(monkeypatch):
+    setup_env(monkeypatch)
+    from accscore.db.events import log_event
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE job_tasks (id TEXT PRIMARY KEY, job_id TEXT NOT NULL)"))
+        conn.execute(
+            text(
+                """
+                CREATE TABLE task_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    job_id TEXT NOT NULL,
+                    job_task_id TEXT,
+                    ts TEXT NOT NULL,
+                    source TEXT,
+                    level TEXT,
+                    type TEXT,
+                    message TEXT,
+                    data TEXT
+                )
+                """
+            )
+        )
+        conn.execute(text("INSERT INTO job_tasks (id, job_id) VALUES ('t1','j1')"))
+
+        with pytest.raises(ValueError):
+            log_event("info", "log", "bad", job_id="j2", job_task_id="t1", conn=conn)


### PR DESCRIPTION
## Summary
- convert `db` module into package to support new event utilities
- add `log_event` helper to insert validated task events
- cover event logging with smoke tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962209e4e0832ba1d3a7e15cf359a2