### PR TITLE
Add task selection and claiming helpers with tests

### DIFF
--- a/accscore/db/__init__.py
+++ b/accscore/db/__init__.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker, Session
 
-from .settings import Settings
+from ..settings import Settings
 
 
 settings = Settings()

--- a/accscore/db/tasks.py
+++ b/accscore/db/tasks.py
@@ -1,0 +1,125 @@
+"""Utilities for selecting and claiming runnable tasks."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+
+JobTaskRow = Dict[str, Any]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _get_capacity(service_name: str, limit: int, *, conn: Connection) -> int:
+    """Compute remaining capacity for a service respecting node limits."""
+
+    running = conn.execute(
+        text(
+            """
+            SELECT count(*)
+            FROM job_tasks
+            WHERE service_name = :service
+              AND status IN ('starting', 'running')
+            """
+        ),
+        {"service": service_name},
+    ).scalar_one()
+
+    max_concurrency = conn.execute(
+        text(
+            """
+            SELECT sum((max_concurrency->>:service)::int)
+            FROM nodes
+            WHERE max_concurrency ? :service
+            """
+        ),
+        {"service": service_name},
+    ).scalar_one()
+
+    if max_concurrency is None:
+        return limit
+
+    remaining = max_concurrency - running
+    if remaining <= 0:
+        return 0
+    return min(limit, remaining)
+
+
+def select_runnable(
+    service_name: str,
+    limit: int,
+    *,
+    conn: Connection,
+    now: Optional[datetime] = None,
+) -> List[JobTaskRow]:
+    """Select runnable tasks for a service using row-level locks.
+
+    The caller is responsible for running this inside a transaction so that the
+    selected rows remain locked until :func:`claim_tasks` is invoked.
+    """
+
+    now = now or _utcnow()
+    capacity = _get_capacity(service_name, limit, conn=conn)
+    if capacity <= 0:
+        return []
+
+    sql = text(
+        """
+        SELECT jt.*
+        FROM job_tasks jt
+        JOIN jobs j ON j.id = jt.job_id
+        WHERE jt.service_name = :service
+          AND jt.status = 'queued'
+          AND (jt.next_attempt_at IS NULL OR jt.next_attempt_at <= :now)
+          AND NOT EXISTS (
+            SELECT 1 FROM job_tasks dep
+            WHERE dep.job_id = jt.job_id
+              AND dep.task_key = ANY(jt.depends_on)
+              AND dep.status <> 'done'
+          )
+        ORDER BY j.order_seq ASC, jt.created_at ASC, jt.id ASC
+        FOR UPDATE SKIP LOCKED
+        LIMIT :limit
+        """
+    )
+
+    rows = conn.execute(
+        sql, {"service": service_name, "now": now, "limit": capacity}
+    ).mappings()
+    return [dict(row) for row in rows]
+
+
+def claim_tasks(
+    task_ids: List[UUID],
+    node_name: str,
+    *,
+    conn: Connection,
+    now: Optional[datetime] = None,
+) -> int:
+    """Claim previously selected tasks for a node."""
+
+    if not task_ids:
+        return 0
+
+    now = now or _utcnow()
+    sql = text(
+        """
+        UPDATE job_tasks
+        SET claimed_by = :node,
+            assigned_node = :node,
+            status = 'starting',
+            claimed_at = :now
+        WHERE id = ANY(:ids)
+        """
+    )
+
+    result = conn.execute(sql, {"node": node_name, "now": now, "ids": list(task_ids)})
+    return result.rowcount or 0
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = [
+    "pytest",
+    "testcontainers",
+    "psycopg2-binary",
+]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,123 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import os
+
+from sqlalchemy import create_engine, text
+
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+import docker
+from docker.errors import DockerException
+
+
+def _docker_available() -> bool:
+    try:
+        docker.from_env().ping()
+        return True
+    except Exception:
+        return False
+
+os.environ.setdefault("MINIO_ENDPOINT", "dummy")
+os.environ.setdefault("MINIO_ACCESS_KEY", "key")
+os.environ.setdefault("MINIO_SECRET_KEY", "secret")
+os.environ.setdefault("POSTGRES_DSN", "sqlite://")
+
+from accscore.db.tasks import claim_tasks, select_runnable
+
+
+def _setup_schema(conn):
+    conn.execute(
+        text(
+            """
+            CREATE TABLE jobs (
+                id uuid PRIMARY KEY,
+                order_seq bigint NOT NULL
+            );
+            CREATE TABLE job_tasks (
+                id uuid PRIMARY KEY,
+                job_id uuid REFERENCES jobs(id),
+                task_key text NOT NULL,
+                service_name text NOT NULL,
+                status text NOT NULL,
+                depends_on text[] NOT NULL DEFAULT '{}',
+                next_attempt_at timestamptz,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                assigned_node text,
+                claimed_by text,
+                claimed_at timestamptz
+            );
+            CREATE TABLE nodes (
+                name text PRIMARY KEY,
+                max_concurrency jsonb
+            );
+            """
+        )
+    )
+
+
+def _insert_sample_data(conn):
+    now = datetime.now(timezone.utc)
+    conn.execute(
+        text("INSERT INTO nodes (name, max_concurrency) VALUES ('n1', :mc::jsonb)"),
+        {"mc": '{"svc":2}'},
+    )
+
+    j1, j2 = uuid4(), uuid4()
+    conn.execute(
+        text("INSERT INTO jobs (id, order_seq) VALUES (:j1, 1), (:j2, 2)"),
+        {"j1": j1, "j2": j2},
+    )
+
+    tasks = []
+    for job_id, prefix in [(j1, "a"), (j2, "b")]:
+        t1 = uuid4()
+        t2 = uuid4()
+        t3 = uuid4()
+        tasks.append((t1, job_id, f"{prefix}1", []))
+        tasks.append((t2, job_id, f"{prefix}2", [f"{prefix}1"]))
+        tasks.append((t3, job_id, f"{prefix}3", [f"{prefix}2"]))
+
+    for tid, job_id, key, deps in tasks:
+        conn.execute(
+            text(
+                """
+                INSERT INTO job_tasks (id, job_id, task_key, service_name, status, depends_on, created_at)
+                VALUES (:id, :job_id, :key, 'svc', 'queued', :deps, :now)
+                """
+            ),
+            {"id": tid, "job_id": job_id, "key": key, "deps": deps, "now": now},
+        )
+
+
+@pytest.mark.skipif(not _docker_available(), reason="Docker not available")
+def test_select_and_claim_runnable_tasks():
+    with PostgresContainer("postgres:15-alpine") as pg:
+        engine = create_engine(pg.get_connection_url(), future=True)
+        with engine.begin() as conn:
+            _setup_schema(conn)
+            _insert_sample_data(conn)
+
+        with engine.begin() as conn:
+            tasks = select_runnable("svc", 10, conn=conn)
+            assert [t["task_key"] for t in tasks] == ["a1", "b1"]
+            count = claim_tasks([t["id"] for t in tasks], "nodeA", conn=conn)
+            assert count == 2
+
+        with engine.begin() as conn:
+            remaining = select_runnable("svc", 10, conn=conn)
+            assert remaining == []
+
+        # Mark first tasks done and ensure next tasks become runnable
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE job_tasks SET status='done' WHERE task_key IN ('a1', 'b1')"
+                )
+            )
+
+        with engine.begin() as conn:
+            tasks = select_runnable("svc", 10, conn=conn)
+            assert [t["task_key"] for t in tasks] == ["a2", "b2"]
+


### PR DESCRIPTION
## Summary
- turn `accscore.db` into a package and add task utilities
- implement `select_runnable` and `claim_tasks` with capacity and locking
- cover task claiming flow with a PostgreSQL integration test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689621fd2094832b99b85729d4ad366c