### PR TITLE
Add job task instantiation utility

### DIFF
--- a/accscore/db/__init__.py
+++ b/accscore/db/__init__.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker, Session
 
-from .settings import Settings
+from ..settings import Settings
 
 
 settings = Settings()

--- a/accscore/db/jobs.py
+++ b/accscore/db/jobs.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+from sqlalchemy import text
+
+
+
+def instantiate_job_tasks(job_id: UUID, *, conn) -> None:
+    """Instantiate job tasks for a job based on its workflow definition.
+
+    Parameters
+    ----------
+    job_id:
+        Identifier of the job to instantiate tasks for.
+    conn:
+        SQLAlchemy connection to use. The function manages its own transaction.
+    """
+
+    with conn.begin():
+        workflow_id_row = conn.execute(
+            text("SELECT workflow_id FROM jobs WHERE id=:job_id"),
+            {"job_id": str(job_id)},
+        ).one_or_none()
+        if workflow_id_row is None:
+            return
+        workflow_id = workflow_id_row[0]
+
+        steps_row = conn.execute(
+            text("SELECT steps FROM workflows WHERE id=:wf_id"),
+            {"wf_id": workflow_id},
+        ).one_or_none()
+        if steps_row is None:
+            return
+
+        steps = steps_row[0] or []
+        if isinstance(steps, str):
+            steps = json.loads(steps)
+
+        inserted = 0
+        for step in steps:
+            task_key = step.get("key")
+            service_name = step.get("service")
+            depends_on = step.get("depends_on") or []
+            params = step.get("default_params") or {}
+
+            if conn.dialect.name == "sqlite":
+                depends_on_param = json.dumps(depends_on)
+                params_param = json.dumps(params)
+            else:
+                depends_on_param = depends_on
+                params_param = params
+
+            exists = conn.execute(
+                text(
+                    "SELECT 1 FROM job_tasks WHERE job_id=:job_id AND task_key=:task_key"
+                ),
+                {"job_id": str(job_id), "task_key": task_key},
+            ).fetchone()
+            if exists:
+                continue
+
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO job_tasks
+                        (job_id, task_key, service_name, status, depends_on, params, attempt, max_attempts)
+                    VALUES (:job_id, :task_key, :service_name, 'queued', :depends_on, :params, 0, 3)
+                    """
+                ),
+                {
+                    "job_id": str(job_id),
+                    "task_key": task_key,
+                    "service_name": service_name,
+                    "depends_on": depends_on_param,
+                    "params": params_param,
+                },
+            )
+            inserted += 1
+
+        if inserted:
+            conn.execute(
+                text("UPDATE jobs SET status='running' WHERE id=:job_id"),
+                {"job_id": str(job_id)},
+            )

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,90 @@
+import json
+import os
+from uuid import uuid4
+
+os.environ.setdefault("MINIO_ENDPOINT", "example")
+os.environ.setdefault("MINIO_ACCESS_KEY", "key")
+os.environ.setdefault("MINIO_SECRET_KEY", "secret")
+os.environ.setdefault("POSTGRES_DSN", "sqlite:///:memory:")
+
+from sqlalchemy import create_engine, text
+
+from accscore.db.jobs import instantiate_job_tasks
+
+
+def test_instantiate_job_tasks_idempotent():
+    engine = create_engine("sqlite:///:memory:")
+    # setup schema and seed data
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE workflows (id TEXT PRIMARY KEY, steps TEXT)"))
+        conn.execute(
+            text(
+                """
+            CREATE TABLE jobs (
+                id TEXT PRIMARY KEY,
+                workflow_id TEXT,
+                status TEXT
+            )
+            """
+            )
+        )
+        conn.execute(
+            text(
+                """
+            CREATE TABLE job_tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_id TEXT,
+                task_key TEXT,
+                service_name TEXT,
+                status TEXT,
+                depends_on TEXT,
+                params TEXT,
+                attempt INTEGER,
+                max_attempts INTEGER
+            )
+            """
+            )
+        )
+
+        wf_id = uuid4()
+        job_id = uuid4()
+
+        steps = [
+            {"key": "s1", "service": "svc1", "default_params": {"a": 1}},
+            {"key": "s2", "service": "svc2", "depends_on": ["s1"], "default_params": {"b": 2}},
+        ]
+        conn.execute(
+            text("INSERT INTO workflows (id, steps) VALUES (:id, :steps)"),
+            {"id": str(wf_id), "steps": json.dumps(steps)},
+        )
+        conn.execute(
+            text("INSERT INTO jobs (id, workflow_id, status) VALUES (:id, :wf, 'queued')"),
+            {"id": str(job_id), "wf": str(wf_id)},
+        )
+
+    with engine.connect() as conn:
+        instantiate_job_tasks(job_id, conn=conn)
+
+        rows = conn.execute(
+            text(
+                "SELECT task_key, service_name, status, depends_on, params, attempt, max_attempts FROM job_tasks ORDER BY id"
+            )
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0][0] == "s1"
+        assert rows[0][2] == "queued"
+        assert rows[1][0] == "s2"
+        assert json.loads(rows[1][3]) == ["s1"]
+        assert json.loads(rows[0][4]) == {"a": 1}
+        assert rows[0][5] == 0 and rows[0][6] == 3
+
+        status = conn.execute(text("SELECT status FROM jobs WHERE id=:id"), {"id": str(job_id)}).scalar_one()
+        assert status == "running"
+
+        conn.commit()
+
+    with engine.connect() as conn:
+        # idempotency
+        instantiate_job_tasks(job_id, conn=conn)
+        count = conn.execute(text("SELECT COUNT(*) FROM job_tasks")).scalar_one()
+        assert count == 2


### PR DESCRIPTION
## Summary
- refactor db module into package to accommodate more helpers
- add `instantiate_job_tasks` for creating queued tasks from workflow
- cover job task creation with idempotency test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689621f2c638832b84476249ad61adf2