### PR TITLE
Migrate to Pydantic v2 with pydantic-settings

### DIFF
--- a/accscore/settings.py
+++ b/accscore/settings.py
@@ -1,20 +1,30 @@
 """Environment configuration using Pydantic."""
 
-from pydantic import BaseSettings, Field
 from typing import Optional
+
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables or .env file."""
 
-    minio_endpoint: str = Field(..., env=["ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT"])
-    minio_access_key: str = Field(..., env=["ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY"])
-    minio_secret_key: str = Field(..., env=["ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY"])
-    minio_secure: bool = Field(False, env=["ACC_MINIO_SECURE", "MINIO_SECURE"])
-    postgres_dsn: str = Field(..., env=["ACC_DB_URL", "POSTGRES_DSN"])
-    rabbitmq_url: Optional[str] = Field(None, env="RABBITMQ_URL")
-    service_url: Optional[str] = Field(None, env="SERVICE_URL")
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = False
+    minio_endpoint: str = Field(
+        ..., env=["ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT"], validation_alias=AliasChoices("ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT")
+    )
+    minio_access_key: str = Field(
+        ..., env=["ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY"], validation_alias=AliasChoices("ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY")
+    )
+    minio_secret_key: str = Field(
+        ..., env=["ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY"], validation_alias=AliasChoices("ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY")
+    )
+    minio_secure: bool = Field(
+        False, env=["ACC_MINIO_SECURE", "MINIO_SECURE"], validation_alias=AliasChoices("ACC_MINIO_SECURE", "MINIO_SECURE")
+    )
+    postgres_dsn: str = Field(
+        ..., env=["ACC_DB_URL", "POSTGRES_DSN"], validation_alias=AliasChoices("ACC_DB_URL", "POSTGRES_DSN")
+    )
+    rabbitmq_url: Optional[str] = Field(None, env="RABBITMQ_URL", validation_alias="RABBITMQ_URL")
+    service_url: Optional[str] = Field(None, env="SERVICE_URL", validation_alias="SERVICE_URL")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [{name = "ACCS"}]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "pydantic>=1.10,<2",
+    "pydantic>=2.7,<3",
+    "pydantic-settings>=2.2",
     "sqlalchemy>=1.4",
     "minio>=7.1.0",
 ]


### PR DESCRIPTION
## Summary
- upgrade to Pydantic v2 and add pydantic-settings
- adapt Settings configuration to new Pydantic v2 style

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689629a11ec0832b9705b7ccf9a7761b