### PR TITLE
refactor: drop env from settings fields

### DIFF
--- a/accscore/settings.py
+++ b/accscore/settings.py
@@ -12,19 +12,19 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
 
     minio_endpoint: str = Field(
-        ..., env=["ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT"], validation_alias=AliasChoices("ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT")
+        ..., validation_alias=AliasChoices("ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT")
     )
     minio_access_key: str = Field(
-        ..., env=["ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY"], validation_alias=AliasChoices("ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY")
+        ..., validation_alias=AliasChoices("ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY")
     )
     minio_secret_key: str = Field(
-        ..., env=["ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY"], validation_alias=AliasChoices("ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY")
+        ..., validation_alias=AliasChoices("ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY")
     )
     minio_secure: bool = Field(
-        False, env=["ACC_MINIO_SECURE", "MINIO_SECURE"], validation_alias=AliasChoices("ACC_MINIO_SECURE", "MINIO_SECURE")
+        False, validation_alias=AliasChoices("ACC_MINIO_SECURE", "MINIO_SECURE")
     )
     postgres_dsn: str = Field(
-        ..., env=["ACC_DB_URL", "POSTGRES_DSN"], validation_alias=AliasChoices("ACC_DB_URL", "POSTGRES_DSN")
+        ..., validation_alias=AliasChoices("ACC_DB_URL", "POSTGRES_DSN")
     )
-    rabbitmq_url: Optional[str] = Field(None, env="RABBITMQ_URL", validation_alias="RABBITMQ_URL")
-    service_url: Optional[str] = Field(None, env="SERVICE_URL", validation_alias="SERVICE_URL")
+    rabbitmq_url: Optional[str] = Field(None, validation_alias="RABBITMQ_URL")
+    service_url: Optional[str] = Field(None, validation_alias="SERVICE_URL")


### PR DESCRIPTION
## Summary
- remove deprecated `env` parameter from settings

## Testing
- `ruff check accscore/settings.py --fix`
- `ruff format accscore/settings.py`
- `mypy accscore/settings.py` *(fails: Cannot find implementation or library stub for module named "pydantic", "pydantic_settings")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'accscore' / 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68962f090984832b8c06e31f75c32264