### PR TITLE
refactor: use built-in generics

### DIFF
--- a/accscore/db/__init__.py
+++ b/accscore/db/__init__.py
@@ -1,7 +1,7 @@
 """Database utilities using SQLAlchemy."""
 
 from contextlib import contextmanager
-from typing import Iterator, List, Dict, Any, Optional
+from typing import Any, Iterator, Optional
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
@@ -39,7 +39,9 @@ def check_connection() -> bool:
         return False
 
 
-def claim_tasks(session: Session, service: str, capacity: int, agent: str) -> List[Dict[str, Any]]:
+def claim_tasks(
+    session: Session, service: str, capacity: int, agent: str
+) -> list[dict[str, Any]]:
     """Claim queued tasks for a service respecting global job order.
 
     Parameters
@@ -81,7 +83,9 @@ def claim_tasks(session: Session, service: str, capacity: int, agent: str) -> Li
         """
     )
 
-    result = session.execute(sql, {"service": service, "capacity": capacity, "agent": agent})
+    result = session.execute(
+        sql, {"service": service, "capacity": capacity, "agent": agent}
+    )
     return [dict(row) for row in result.mappings()]
 
 
@@ -115,11 +119,15 @@ def mark_task_running(session: Session, task_id: str) -> None:
 
 def update_task_progress(session: Session, task_id: str, percent: float) -> None:
     """Update task progress percentage."""
-    sql = text("UPDATE job_tasks SET progress=:percent, updated_at=now() WHERE id=:task_id")
+    sql = text(
+        "UPDATE job_tasks SET progress=:percent, updated_at=now() WHERE id=:task_id"
+    )
     session.execute(sql, {"task_id": task_id, "percent": percent})
 
 
-def mark_task_done(session: Session, task_id: str, results: Optional[Dict[str, Any]] = None) -> None:
+def mark_task_done(
+    session: Session, task_id: str, results: Optional[dict[str, Any]] = None
+) -> None:
     """Mark a task as done and optionally store results."""
     sql = text(
         "UPDATE job_tasks SET status='done', results=COALESCE(:results, results), finished_at=now() WHERE id=:task_id"
@@ -139,7 +147,10 @@ def mark_task_error(
         WHERE id=:task_id
         """
     )
-    session.execute(sql, {"task_id": task_id, "error_info": {"code": error_code, "message": message}})
+    session.execute(
+        sql,
+        {"task_id": task_id, "error_info": {"code": error_code, "message": message}},
+    )
 
 
 def append_event(
@@ -150,7 +161,7 @@ def append_event(
     level: str = "info",
     type: str = "log",
     message: str = "",
-    data: Optional[Dict[str, Any]] = None,
+    data: Optional[dict[str, Any]] = None,
 ) -> None:
     """Insert a new event row."""
     sql = text(

--- a/accscore/db/events.py
+++ b/accscore/db/events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from datetime import datetime
 import json
 
@@ -17,7 +17,7 @@ def log_event(
     type: str,
     message: str,
     *,
-    data: Optional[Dict[str, Any]] = None,
+    data: Optional[dict[str, Any]] = None,
     job_id: Optional[str] = None,
     job_task_id: Optional[str] = None,
     source: str = "service:unknown",

--- a/accscore/db/tasks.py
+++ b/accscore/db/tasks.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 from uuid import UUID
 
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
 
-JobTaskRow = Dict[str, Any]
+JobTaskRow = dict[str, Any]
 
 
 def _utcnow() -> datetime:
@@ -58,7 +58,7 @@ def select_runnable(
     *,
     conn: Connection,
     now: Optional[datetime] = None,
-) -> List[JobTaskRow]:
+) -> list[JobTaskRow]:
     """Select runnable tasks for a service using row-level locks.
 
     The caller is responsible for running this inside a transaction so that the
@@ -97,7 +97,7 @@ def select_runnable(
 
 
 def claim_tasks(
-    task_ids: List[UUID],
+    task_ids: list[UUID],
     node_name: str,
     *,
     conn: Connection,
@@ -122,4 +122,3 @@ def claim_tasks(
 
     result = conn.execute(sql, {"node": node_name, "now": now, "ids": list(task_ids)})
     return result.rowcount or 0
-

--- a/accscore/schema/__init__.py
+++ b/accscore/schema/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -79,8 +79,8 @@ class WorkflowStep(BaseModel):
 
     key: str
     service: str
-    depends_on: List[str] = Field(default_factory=list)
-    default_params: Dict[str, object] = Field(default_factory=dict)
+    depends_on: list[str] = Field(default_factory=list)
+    default_params: dict[str, object] = Field(default_factory=dict)
 
 
 class WorkflowDef(BaseModel):
@@ -89,7 +89,7 @@ class WorkflowDef(BaseModel):
     id: Optional[UUID] = None
     name: str
     version: int
-    steps: List[WorkflowStep]
+    steps: list[WorkflowStep]
     is_active: bool = True
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -105,7 +105,7 @@ class Job(BaseModel):
     current_task_key: Optional[str] = None
     priority: int = 0
     order_seq: int
-    options: Dict[str, object] = Field(default_factory=dict)
+    options: dict[str, object] = Field(default_factory=dict)
     scheduled_at: Optional[datetime] = None
     error_code: Optional[str] = None
     error_message: Optional[str] = None
@@ -123,14 +123,14 @@ class JobTask(BaseModel):
     task_key: str
     service_name: str
     status: TaskStatus
-    depends_on: List[str] = Field(default_factory=list)
+    depends_on: list[str] = Field(default_factory=list)
     attempt: int = 0
     max_attempts: int = 3
     next_attempt_at: Optional[datetime] = None
     priority: int = 0
     progress: Optional[float] = None
-    params: Dict[str, object] = Field(default_factory=dict)
-    results: Dict[str, object] = Field(default_factory=dict)
+    params: dict[str, object] = Field(default_factory=dict)
+    results: dict[str, object] = Field(default_factory=dict)
     assigned_node: Optional[str] = None
     claimed_by: Optional[str] = None
     claimed_at: Optional[datetime] = None
@@ -151,7 +151,7 @@ class TaskEvent(BaseModel):
     level: EventLevel
     type: EventType
     message: str
-    data: Dict[str, object] = Field(default_factory=dict)
+    data: dict[str, object] = Field(default_factory=dict)
 
 
 class TaskArtifact(BaseModel):
@@ -173,14 +173,14 @@ class Node(BaseModel):
     """Service node participating in the workflow."""
 
     name: str
-    labels: Dict[str, object] = Field(default_factory=dict)
+    labels: dict[str, object] = Field(default_factory=dict)
     last_seen: Optional[datetime] = None
     awake_state: AwakeState = AwakeState.UNKNOWN
     wake_method: Optional[WakeMethod] = None
     mac: Optional[str] = None
     provider_ref: Optional[str] = None
     script: Optional[str] = None
-    max_concurrency: Dict[str, int] = Field(default_factory=dict)
+    max_concurrency: dict[str, int] = Field(default_factory=dict)
 
 
 __all__ = [
@@ -199,4 +199,3 @@ __all__ = [
     "WakeMethod",
     "Node",
 ]
-

--- a/accscore/settings.py
+++ b/accscore/settings.py
@@ -1,5 +1,7 @@
 """Environment configuration using Pydantic."""
 
+from __future__ import annotations
+
 from typing import Optional
 
 from pydantic import AliasChoices, Field
@@ -12,19 +14,33 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
 
     minio_endpoint: str = Field(
-        ..., env=["ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT"], validation_alias=AliasChoices("ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT")
+        ...,
+        env=["ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT"],
+        validation_alias=AliasChoices("ACC_MINIO_ENDPOINT", "MINIO_ENDPOINT"),
     )
     minio_access_key: str = Field(
-        ..., env=["ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY"], validation_alias=AliasChoices("ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY")
+        ...,
+        env=["ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY"],
+        validation_alias=AliasChoices("ACC_MINIO_ACCESS_KEY", "MINIO_ACCESS_KEY"),
     )
     minio_secret_key: str = Field(
-        ..., env=["ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY"], validation_alias=AliasChoices("ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY")
+        ...,
+        env=["ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY"],
+        validation_alias=AliasChoices("ACC_MINIO_SECRET_KEY", "MINIO_SECRET_KEY"),
     )
     minio_secure: bool = Field(
-        False, env=["ACC_MINIO_SECURE", "MINIO_SECURE"], validation_alias=AliasChoices("ACC_MINIO_SECURE", "MINIO_SECURE")
+        False,
+        env=["ACC_MINIO_SECURE", "MINIO_SECURE"],
+        validation_alias=AliasChoices("ACC_MINIO_SECURE", "MINIO_SECURE"),
     )
     postgres_dsn: str = Field(
-        ..., env=["ACC_DB_URL", "POSTGRES_DSN"], validation_alias=AliasChoices("ACC_DB_URL", "POSTGRES_DSN")
+        ...,
+        env=["ACC_DB_URL", "POSTGRES_DSN"],
+        validation_alias=AliasChoices("ACC_DB_URL", "POSTGRES_DSN"),
     )
-    rabbitmq_url: Optional[str] = Field(None, env="RABBITMQ_URL", validation_alias="RABBITMQ_URL")
-    service_url: Optional[str] = Field(None, env="SERVICE_URL", validation_alias="SERVICE_URL")
+    rabbitmq_url: Optional[str] = Field(
+        None, env="RABBITMQ_URL", validation_alias="RABBITMQ_URL"
+    )
+    service_url: Optional[str] = Field(
+        None, env="SERVICE_URL", validation_alias="SERVICE_URL"
+    )


### PR DESCRIPTION
## Summary
- replace `typing.List`/`typing.Dict` with built-in generics
- add `from __future__ import annotations` to Pydantic settings module

## Testing
- `ruff check --fix accscore/settings.py accscore/db/events.py accscore/db/__init__.py accscore/db/tasks.py accscore/schema/__init__.py`
- `ruff format accscore/settings.py accscore/db/events.py accscore/db/__init__.py accscore/db/tasks.py accscore/schema/__init__.py`
- `mypy --install-types --non-interactive accscore tests` (fails: Incompatible types / missing stubs)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68962f71f5cc832baab66504fc06a48f