### PR TITLE
chore: add ruff and mypy pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,19 @@ test = [
     "testcontainers",
     "psycopg2-binary",
 ]
+
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E","F","B","UP","I","N","PTH","D","C90"]
+ignore = ["D105","D107"]
+mccabe.max-complexity = 10
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"


### PR DESCRIPTION
## Summary
- configure Ruff linting and formatting in `pyproject.toml`
- add pre-commit hooks for Ruff and mypy

## Testing
- `pre-commit run --files pyproject.toml .pre-commit-config.yaml`
- `mypy accscore` *(fails: Found 25 errors in 5 files)*

------
https://chatgpt.com/codex/tasks/task_e_68962f75ec6c832b9a3e61836073976e